### PR TITLE
Create Visualization is skipping the entries from CSV file

### DIFF
--- a/Visualization is skipping the entries from CSV file
+++ b/Visualization is skipping the entries from CSV file
@@ -1,0 +1,3 @@
+Visualization added to the suoerset, keeps skipping the entries from the csv file.
+
+So if we create a file that contains 10 entties only 4 would be shown.


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement).

if we try to create new image grid chart for the csv with image urls.
Then it skips the rows randomly.
So in case of 10 row data it will show 4 images as output.
And so on.
